### PR TITLE
fix(jose): jws hmac now correctly uses timing safe comparison

### DIFF
--- a/packages/jose/lib/jws/algorithms/hmac.ts
+++ b/packages/jose/lib/jws/algorithms/hmac.ts
@@ -1,4 +1,4 @@
-import { createHmac, KeyObject } from 'crypto';
+import { createHmac, KeyObject, timingSafeEqual } from 'crypto';
 
 import { InvalidJsonWebKeyException } from '../../exceptions/invalid-json-web-key.exception';
 import { InvalidJsonWebSignatureException } from '../../exceptions/invalid-json-web-signature.exception';
@@ -56,7 +56,7 @@ class HmacAlgorithm extends JsonWebSignatureAlgorithm {
 
     const calculatedSignature = await this.sign(message, key);
 
-    if (signature.compare(calculatedSignature) !== 0) {
+    if (!timingSafeEqual(signature, calculatedSignature)) {
       throw new InvalidJsonWebSignatureException();
     }
   }


### PR DESCRIPTION
JSON Web Signature HMAC Algorithm now correctly uses timing safe comparison when verifying a signature.