### PR TITLE
feat(oauth2-server): use login and consent challenge on interactions

### DIFF
--- a/packages/oauth2-server/src/lib/endpoints/authorization.endpoint.spec.ts
+++ b/packages/oauth2-server/src/lib/endpoints/authorization.endpoint.spec.ts
@@ -41,6 +41,7 @@ describe('Authorization Endpoint', () => {
   const sessionServiceMock = jest.mocked<SessionServiceInterface>({
     create: jest.fn(),
     findOne: jest.fn(),
+    findOneByLoginChallenge: jest.fn(),
     remove: jest.fn(),
     save: jest.fn(),
   });
@@ -48,6 +49,7 @@ describe('Authorization Endpoint', () => {
   const consentServiceMock = jest.mocked<ConsentServiceInterface>({
     create: jest.fn(),
     findOne: jest.fn(),
+    findOneByConsentChallenge: jest.fn(),
     remove: jest.fn(),
     save: jest.fn(),
   });
@@ -348,9 +350,9 @@ describe('Authorization Endpoint', () => {
         scopes: ['foo', 'bar'],
       });
 
-      sessionServiceMock.create.mockResolvedValueOnce(<Session>{ id: 'session_id' });
+      sessionServiceMock.create.mockResolvedValueOnce(<Session>{ id: 'session_id', loginChallenge: 'login_challenge' });
 
-      const parameters = new URLSearchParams({ login_challenge: 'session_id' });
+      const parameters = new URLSearchParams({ login_challenge: 'login_challenge' });
 
       await expect(endpoint.handle(request)).resolves.toMatchObject<Partial<HttpResponse>>({
         body: Buffer.alloc(0),
@@ -369,9 +371,9 @@ describe('Authorization Endpoint', () => {
       });
 
       sessionServiceMock.findOne.mockResolvedValueOnce(null);
-      sessionServiceMock.create.mockResolvedValueOnce(<Session>{ id: 'session_id' });
+      sessionServiceMock.create.mockResolvedValueOnce(<Session>{ id: 'session_id', loginChallenge: 'login_challenge' });
 
-      const parameters = new URLSearchParams({ login_challenge: 'session_id' });
+      const parameters = new URLSearchParams({ login_challenge: 'login_challenge' });
 
       await expect(endpoint.handle(request)).resolves.toMatchObject<Partial<HttpResponse>>({
         body: Buffer.alloc(0),
@@ -391,12 +393,13 @@ describe('Authorization Endpoint', () => {
 
       sessionServiceMock.findOne.mockResolvedValueOnce(<Session>{
         id: 'session_id',
+        loginChallenge: 'old_login_challenge',
         expiresAt: new Date(Date.now() - 3600000),
       });
 
-      sessionServiceMock.create.mockResolvedValueOnce(<Session>{ id: 'session_id' });
+      sessionServiceMock.create.mockResolvedValueOnce(<Session>{ id: 'session_id', loginChallenge: 'login_challenge' });
 
-      const parameters = new URLSearchParams({ login_challenge: 'session_id' });
+      const parameters = new URLSearchParams({ login_challenge: 'login_challenge' });
 
       await expect(endpoint.handle(request)).resolves.toMatchObject<Partial<HttpResponse>>({
         body: Buffer.alloc(0),
@@ -416,10 +419,15 @@ describe('Authorization Endpoint', () => {
         scopes: ['foo', 'bar'],
       });
 
-      sessionServiceMock.findOne.mockResolvedValueOnce(<Session>{ id: 'session_id', user: null });
-      sessionServiceMock.create.mockResolvedValueOnce(<Session>{ id: 'session_id' });
+      sessionServiceMock.findOne.mockResolvedValueOnce(<Session>{
+        id: 'session_id',
+        loginChallenge: 'old_login_challenge',
+        user: null,
+      });
 
-      const parameters = new URLSearchParams({ login_challenge: 'session_id' });
+      sessionServiceMock.create.mockResolvedValueOnce(<Session>{ id: 'session_id', loginChallenge: 'login_challenge' });
+
+      const parameters = new URLSearchParams({ login_challenge: 'login_challenge' });
 
       await expect(endpoint.handle(request)).resolves.toMatchObject<Partial<HttpResponse>>({
         body: Buffer.alloc(0),
@@ -443,6 +451,7 @@ describe('Authorization Endpoint', () => {
 
       sessionServiceMock.findOne.mockResolvedValueOnce(<Session>{
         id: 'session_id',
+        loginChallenge: 'login_challenge',
         parameters: { ...request.query, state: 'client_state' },
         user: { id: 'user_id' },
       });
@@ -479,13 +488,18 @@ describe('Authorization Endpoint', () => {
 
       sessionServiceMock.findOne.mockResolvedValueOnce(<Session>{
         id: 'session_id',
+        loginChallenge: 'login_challenge',
         parameters: request.query,
         user: { id: 'user_id' },
       });
 
-      consentServiceMock.create.mockResolvedValueOnce(<Consent>{ id: 'consent_id' });
+      consentServiceMock.create.mockResolvedValueOnce(<Consent>{
+        id: 'consent_id',
+        loginChallenge: 'login_challenge',
+        consentChallenge: 'consent_challenge',
+      });
 
-      const parameters = new URLSearchParams({ consent_challenge: 'consent_id' });
+      const parameters = new URLSearchParams({ consent_challenge: 'consent_challenge' });
 
       await expect(endpoint.handle(request)).resolves.toMatchObject<Partial<HttpResponse>>({
         body: Buffer.alloc(0),
@@ -505,14 +519,19 @@ describe('Authorization Endpoint', () => {
 
       sessionServiceMock.findOne.mockResolvedValueOnce(<Session>{
         id: 'session_id',
+        loginChallenge: 'login_challenge',
         parameters: request.query,
         user: { id: 'user_id' },
       });
 
       consentServiceMock.findOne.mockResolvedValueOnce(null);
-      consentServiceMock.create.mockResolvedValueOnce(<Consent>{ id: 'consent_id' });
+      consentServiceMock.create.mockResolvedValueOnce(<Consent>{
+        id: 'consent_id',
+        loginChallenge: 'login_challenge',
+        consentChallenge: 'consent_challenge',
+      });
 
-      const parameters = new URLSearchParams({ consent_challenge: 'consent_id' });
+      const parameters = new URLSearchParams({ consent_challenge: 'consent_challenge' });
 
       await expect(endpoint.handle(request)).resolves.toMatchObject<Partial<HttpResponse>>({
         body: Buffer.alloc(0),
@@ -532,18 +551,25 @@ describe('Authorization Endpoint', () => {
 
       sessionServiceMock.findOne.mockResolvedValueOnce(<Session>{
         id: 'session_id',
+        loginChallenge: 'login_challenge',
         parameters: request.query,
         user: { id: 'user_id' },
       });
 
       consentServiceMock.findOne.mockResolvedValueOnce(<Consent>{
         id: 'consent_id',
+        loginChallenge: 'old_login_challenge',
+        consentChallenge: 'old_consent_challenge',
         expiresAt: new Date(Date.now() - 3600000),
       });
 
-      consentServiceMock.create.mockResolvedValueOnce(<Consent>{ id: 'consent_id' });
+      consentServiceMock.create.mockResolvedValueOnce(<Consent>{
+        id: 'consent_id',
+        loginChallenge: 'login_challenge',
+        consentChallenge: 'consent_challenge',
+      });
 
-      const parameters = new URLSearchParams({ consent_challenge: 'consent_id' });
+      const parameters = new URLSearchParams({ consent_challenge: 'consent_challenge' });
 
       await expect(endpoint.handle(request)).resolves.toMatchObject<Partial<HttpResponse>>({
         body: Buffer.alloc(0),
@@ -567,12 +593,15 @@ describe('Authorization Endpoint', () => {
 
       sessionServiceMock.findOne.mockResolvedValueOnce(<Session>{
         id: 'session_id',
+        loginChallenge: 'login_challenge',
         parameters: { ...request.query, state: 'client_state' },
         user: { id: 'user_id' },
       });
 
       consentServiceMock.findOne.mockResolvedValueOnce(<Consent>{
         id: 'consent_id',
+        loginChallenge: 'login_challenge',
+        consentChallenge: 'consent_challenge',
         parameters: { ...request.query, state: 'client_state' },
       });
 
@@ -608,11 +637,16 @@ describe('Authorization Endpoint', () => {
 
       sessionServiceMock.findOne.mockResolvedValueOnce(<Session>{
         id: 'session_id',
+        loginChallenge: 'login_challenge',
         parameters: request.query,
         user: { id: 'user_id' },
       });
 
-      consentServiceMock.findOne.mockResolvedValueOnce(<Consent>{ id: 'consent_id' });
+      consentServiceMock.findOne.mockResolvedValueOnce(<Consent>{
+        id: 'consent_id',
+        loginChallenge: 'login_challenge',
+        consentChallenge: 'consent_challenge',
+      });
 
       responseTypesMocks[0]!.handle.mockResolvedValueOnce({ code: 'code', state: 'client_state' });
 

--- a/packages/oauth2-server/src/lib/endpoints/authorization.endpoint.ts
+++ b/packages/oauth2-server/src/lib/endpoints/authorization.endpoint.ts
@@ -390,7 +390,7 @@ export class AuthorizationEndpoint implements EndpointInterface {
     const session = await this.sessionService.create(parameters, client);
 
     const redirectUrl = new URL(this.loginUrl);
-    const searchParameters = new URLSearchParams({ login_challenge: session.id });
+    const searchParameters = new URLSearchParams({ login_challenge: session.loginChallenge });
 
     redirectUrl.search = searchParameters.toString();
 
@@ -451,10 +451,10 @@ export class AuthorizationEndpoint implements EndpointInterface {
    * @returns Http Redirect Response to the Consent Page.
    */
   private async redirectToConsentPage(parameters: AuthorizationRequest, session: Session): Promise<HttpResponse> {
-    const consent = await this.consentService.create(parameters, session.id, session.client, session.user!);
+    const consent = await this.consentService.create(parameters, session.loginChallenge, session.client, session.user!);
 
     const redirectUrl = new URL(this.consentUrl);
-    const searchParams = new URLSearchParams({ consent_challenge: consent.id });
+    const searchParams = new URLSearchParams({ consent_challenge: consent.consentChallenge });
 
     redirectUrl.search = searchParams.toString();
 

--- a/packages/oauth2-server/src/lib/entities/consent.entity.ts
+++ b/packages/oauth2-server/src/lib/entities/consent.entity.ts
@@ -22,6 +22,11 @@ export interface Consent extends Record<string, any> {
   readonly loginChallenge: string;
 
   /**
+   * Consent Challenge of the Consent.
+   */
+  readonly consentChallenge: string;
+
+  /**
    * Parameters of the Authorization Request.
    */
   readonly parameters: AuthorizationRequest;

--- a/packages/oauth2-server/src/lib/entities/session.entity.ts
+++ b/packages/oauth2-server/src/lib/entities/session.entity.ts
@@ -12,6 +12,11 @@ export interface Session {
   readonly id: string;
 
   /**
+   * Login Challenge of the Session.
+   */
+  readonly loginChallenge: string;
+
+  /**
    * Parameters of the Authorization Request.
    */
   readonly parameters: AuthorizationRequest;

--- a/packages/oauth2-server/src/lib/interaction-types/consent.interaction-type.spec.ts
+++ b/packages/oauth2-server/src/lib/interaction-types/consent.interaction-type.spec.ts
@@ -24,6 +24,7 @@ describe('Consent Interaction Type', () => {
   const consentServiceMock = jest.mocked<ConsentServiceInterface>({
     create: jest.fn(),
     findOne: jest.fn(),
+    findOneByConsentChallenge: jest.fn(),
     remove: jest.fn(),
     save: jest.fn(),
   });
@@ -66,16 +67,18 @@ describe('Consent Interaction Type', () => {
     });
 
     it('should throw when no consent is found.', async () => {
-      consentServiceMock.findOne.mockResolvedValueOnce(null);
+      consentServiceMock.findOneByConsentChallenge.mockResolvedValueOnce(null);
 
       await expect(interactionType.handleContext(parameters)).rejects.toThrow(
-        new AccessDeniedException({ description: 'Invalid Consent.' })
+        new AccessDeniedException({ description: 'Invalid Consent Challenge.' })
       );
     });
 
     it('should throw when the consent is expired.', async () => {
-      consentServiceMock.findOne.mockResolvedValueOnce(<Consent>{
+      consentServiceMock.findOneByConsentChallenge.mockResolvedValueOnce(<Consent>{
         id: 'consent_id',
+        loginChallenge: 'login_challenge',
+        consentChallenge: 'consent_challenge',
         expiresAt: new Date(Date.now() - 3600000),
       });
 
@@ -94,10 +97,11 @@ describe('Consent Interaction Type', () => {
         response_mode: 'query',
       };
 
-      consentServiceMock.findOne.mockResolvedValueOnce(<Consent>{
+      consentServiceMock.findOneByConsentChallenge.mockResolvedValueOnce(<Consent>{
         id: 'consent_id',
         scopes: <string[]>[],
-        loginChallenge: 'session_id',
+        loginChallenge: 'login_challenge',
+        consentChallenge: 'consent_challenge',
         parameters: consentParameters,
         client: { id: 'client_id' },
         user: { id: 'user_id' },
@@ -111,7 +115,7 @@ describe('Consent Interaction Type', () => {
           requested_scope: 'foo bar baz',
           subject: 'user_id',
           request_url: `https://server.example.com/oauth/authorize?${urlParameters.toString()}`,
-          login_challenge: 'session_id',
+          login_challenge: 'login_challenge',
           client: <Client>{ id: 'client_id' },
           context: {},
         }
@@ -147,16 +151,18 @@ describe('Consent Interaction Type', () => {
     });
 
     it('should throw when no consent is found.', async () => {
-      consentServiceMock.findOne.mockResolvedValueOnce(null);
+      consentServiceMock.findOneByConsentChallenge.mockResolvedValueOnce(null);
 
       await expect(interactionType.handleDecision(parameters)).rejects.toThrow(
-        new AccessDeniedException({ description: 'Invalid Consent.' })
+        new AccessDeniedException({ description: 'Invalid Consent Challenge.' })
       );
     });
 
     it('should throw when the consent is expired.', async () => {
-      consentServiceMock.findOne.mockResolvedValueOnce(<Consent>{
+      consentServiceMock.findOneByConsentChallenge.mockResolvedValueOnce(<Consent>{
         id: 'consent_id',
+        loginChallenge: 'login_challenge',
+        consentChallenge: 'consent_challenge',
         expiresAt: new Date(Date.now() - 3600000),
       });
 
@@ -168,7 +174,11 @@ describe('Consent Interaction Type', () => {
     it('should throw when providing an invalid decision.', async () => {
       Reflect.set(parameters, 'decision', 'unknown');
 
-      consentServiceMock.findOne.mockResolvedValueOnce(<Consent>{ id: 'consent_id' });
+      consentServiceMock.findOneByConsentChallenge.mockResolvedValueOnce(<Consent>{
+        id: 'consent_id',
+        loginChallenge: 'login_challenge',
+        consentChallenge: 'consent_challenge',
+      });
 
       await expect(interactionType.handleDecision(parameters)).rejects.toThrow(
         new InvalidRequestException({ description: 'Unsupported decision "unknown".' })
@@ -178,7 +188,11 @@ describe('Consent Interaction Type', () => {
     it('should throw when the parameter "grant_scope" is not provided.', async () => {
       Reflect.set(parameters, 'decision', 'accept');
 
-      consentServiceMock.findOne.mockResolvedValueOnce(<Consent>{ id: 'consent_id' });
+      consentServiceMock.findOneByConsentChallenge.mockResolvedValueOnce(<Consent>{
+        id: 'consent_id',
+        loginChallenge: 'login_challenge',
+        consentChallenge: 'consent_challenge',
+      });
 
       await expect(interactionType.handleDecision(parameters)).rejects.toThrow(
         new InvalidRequestException({ description: 'Invalid parameter "grant_scope".' })
@@ -189,8 +203,10 @@ describe('Consent Interaction Type', () => {
       Reflect.set(parameters, 'decision', 'accept');
       Reflect.set(parameters, 'grant_scope', 'foo bar qux');
 
-      consentServiceMock.findOne.mockResolvedValueOnce(<Consent>{
+      consentServiceMock.findOneByConsentChallenge.mockResolvedValueOnce(<Consent>{
         id: 'consent_id',
+        loginChallenge: 'login_challenge',
+        consentChallenge: 'consent_challenge',
         parameters: { scope: 'foo bar baz' },
       });
 
@@ -212,9 +228,14 @@ describe('Consent Interaction Type', () => {
         response_mode: 'query',
       };
 
-      const consent = <Consent>{ id: 'consent_id', parameters: consentParameters };
+      const consent = <Consent>{
+        id: 'consent_id',
+        loginChallenge: 'login_challenge',
+        consentChallenge: 'consent_challenge',
+        parameters: consentParameters,
+      };
 
-      consentServiceMock.findOne.mockResolvedValueOnce(consent);
+      consentServiceMock.findOneByConsentChallenge.mockResolvedValueOnce(consent);
 
       const urlParameters = new URLSearchParams(consentParameters);
 
@@ -231,7 +252,11 @@ describe('Consent Interaction Type', () => {
     it('should throw when the parameter "error" is not provided.', async () => {
       Reflect.set(parameters, 'decision', 'deny');
 
-      consentServiceMock.findOne.mockResolvedValueOnce(<Consent>{ id: 'consent_id' });
+      consentServiceMock.findOneByConsentChallenge.mockResolvedValueOnce(<Consent>{
+        id: 'consent_id',
+        loginChallenge: 'login_challenge',
+        consentChallenge: 'consent_challenge',
+      });
 
       await expect(interactionType.handleDecision(parameters)).rejects.toThrow(
         new InvalidRequestException({ description: 'Invalid parameter "error".' })
@@ -244,7 +269,11 @@ describe('Consent Interaction Type', () => {
 
       Reflect.deleteProperty(parameters, 'error_description');
 
-      consentServiceMock.findOne.mockResolvedValueOnce(<Consent>{ id: 'consent_id' });
+      consentServiceMock.findOneByConsentChallenge.mockResolvedValueOnce(<Consent>{
+        id: 'consent_id',
+        loginChallenge: 'login_challenge',
+        consentChallenge: 'consent_challenge',
+      });
 
       await expect(interactionType.handleDecision(parameters)).rejects.toThrow(
         new InvalidRequestException({ description: 'Invalid parameter "error_description".' })
@@ -256,7 +285,11 @@ describe('Consent Interaction Type', () => {
       Reflect.set(parameters, 'error', 'custom_error');
       Reflect.set(parameters, 'error_description', 'Custom error description.');
 
-      consentServiceMock.findOne.mockResolvedValueOnce(<Consent>{ id: 'consent_id' });
+      consentServiceMock.findOneByConsentChallenge.mockResolvedValueOnce(<Consent>{
+        id: 'consent_id',
+        loginChallenge: 'login_challenge',
+        consentChallenge: 'consent_challenge',
+      });
 
       const urlParameters = new URLSearchParams({
         error: parameters.error,

--- a/packages/oauth2-server/src/lib/interaction-types/consent.interaction-type.ts
+++ b/packages/oauth2-server/src/lib/interaction-types/consent.interaction-type.ts
@@ -67,7 +67,7 @@ export class ConsentInteractionType implements InteractionTypeInterface {
   public async handleContext(parameters: ConsentContextInteractionRequest): Promise<ConsentContextInteractionResponse> {
     this.checkContextParameters(parameters);
 
-    const consent = await this.getConsent(parameters.consent_challenge);
+    const consent = await this.getConsentByConsentChallenge(parameters.consent_challenge);
 
     await this.checkConsent(consent);
 
@@ -114,7 +114,7 @@ export class ConsentInteractionType implements InteractionTypeInterface {
   ): Promise<ConsentDecisionInteractionResponse> {
     this.checkDecisionParameters(parameters);
 
-    const consent = await this.getConsent(parameters.consent_challenge);
+    const consent = await this.getConsentByConsentChallenge(parameters.consent_challenge);
 
     await this.checkConsent(consent);
 
@@ -248,14 +248,14 @@ export class ConsentInteractionType implements InteractionTypeInterface {
   /**
    * Fetches the requested Consent from the application's storage.
    *
-   * @param id Identifier of the Consent provided by the Client.
-   * @returns Consent based on the provided Identifier.
+   * @param consentChallenge Consent Challenge of the Consent provided by the Client.
+   * @returns Consent based on the provided Consent Challenge.
    */
-  private async getConsent(id: string): Promise<Consent> {
-    const consent = await this.consentService.findOne(id);
+  private async getConsentByConsentChallenge(consentChallenge: string): Promise<Consent> {
+    const consent = await this.consentService.findOneByConsentChallenge(consentChallenge);
 
     if (consent === null) {
-      throw new AccessDeniedException({ description: 'Invalid Consent.' });
+      throw new AccessDeniedException({ description: 'Invalid Consent Challenge.' });
     }
 
     return consent;

--- a/packages/oauth2-server/src/lib/interaction-types/login.interaction-type.spec.ts
+++ b/packages/oauth2-server/src/lib/interaction-types/login.interaction-type.spec.ts
@@ -28,6 +28,7 @@ describe('Login Interaction Type', () => {
   const sessionServiceMock = jest.mocked<SessionServiceInterface>({
     create: jest.fn(),
     findOne: jest.fn(),
+    findOneByLoginChallenge: jest.fn(),
     remove: jest.fn(),
     save: jest.fn(),
   });
@@ -75,16 +76,17 @@ describe('Login Interaction Type', () => {
     });
 
     it('should throw when no session is found.', async () => {
-      sessionServiceMock.findOne.mockResolvedValueOnce(null);
+      sessionServiceMock.findOneByLoginChallenge.mockResolvedValueOnce(null);
 
       await expect(interactionType.handleContext(parameters)).rejects.toThrow(
-        new AccessDeniedException({ description: 'Invalid Session.' })
+        new AccessDeniedException({ description: 'Invalid Login Challenge.' })
       );
     });
 
     it('should throw when the session is expired.', async () => {
-      sessionServiceMock.findOne.mockResolvedValueOnce(<Session>{
+      sessionServiceMock.findOneByLoginChallenge.mockResolvedValueOnce(<Session>{
         id: 'session_id',
+        loginChallenge: 'login_challenge',
         expiresAt: new Date(Date.now() - 3600000),
       });
 
@@ -103,8 +105,9 @@ describe('Login Interaction Type', () => {
         response_mode: 'query',
       };
 
-      sessionServiceMock.findOne.mockResolvedValueOnce(<Session>{
+      sessionServiceMock.findOneByLoginChallenge.mockResolvedValueOnce(<Session>{
         id: 'session_id',
+        loginChallenge: 'login_challenge',
         parameters: sessionParameters,
         client: { id: 'client_id' },
         user: null,
@@ -130,8 +133,9 @@ describe('Login Interaction Type', () => {
         response_mode: 'query',
       };
 
-      sessionServiceMock.findOne.mockResolvedValueOnce(<Session>{
+      sessionServiceMock.findOneByLoginChallenge.mockResolvedValueOnce(<Session>{
         id: 'session_id',
+        loginChallenge: 'login_challenge',
         parameters: sessionParameters,
         client: { id: 'client_id' },
         user: { id: 'user_id' },
@@ -172,16 +176,17 @@ describe('Login Interaction Type', () => {
     });
 
     it('should throw when no session is found.', async () => {
-      sessionServiceMock.findOne.mockResolvedValueOnce(null);
+      sessionServiceMock.findOneByLoginChallenge.mockResolvedValueOnce(null);
 
       await expect(interactionType.handleDecision(parameters)).rejects.toThrow(
-        new AccessDeniedException({ description: 'Invalid Session.' })
+        new AccessDeniedException({ description: 'Invalid Login Challenge.' })
       );
     });
 
     it('should throw when the session is expired.', async () => {
-      sessionServiceMock.findOne.mockResolvedValueOnce(<Session>{
+      sessionServiceMock.findOneByLoginChallenge.mockResolvedValueOnce(<Session>{
         id: 'session_id',
+        loginChallenge: 'login_challenge',
         expiresAt: new Date(Date.now() - 3600000),
       });
 
@@ -193,7 +198,10 @@ describe('Login Interaction Type', () => {
     it('should throw when providing an invalid decision.', async () => {
       Reflect.set(parameters, 'decision', 'unknown');
 
-      sessionServiceMock.findOne.mockResolvedValueOnce(<Session>{ id: 'session_id' });
+      sessionServiceMock.findOneByLoginChallenge.mockResolvedValueOnce(<Session>{
+        id: 'session_id',
+        loginChallenge: 'login_challenge',
+      });
 
       await expect(interactionType.handleDecision(parameters)).rejects.toThrow(
         new InvalidRequestException({ description: 'Unsupported decision "unknown".' })
@@ -203,7 +211,10 @@ describe('Login Interaction Type', () => {
     it('should throw when the parameter "subject" is not provided.', async () => {
       Reflect.set(parameters, 'decision', 'accept');
 
-      sessionServiceMock.findOne.mockResolvedValueOnce(<Session>{ id: 'session_id' });
+      sessionServiceMock.findOneByLoginChallenge.mockResolvedValueOnce(<Session>{
+        id: 'session_id',
+        loginChallenge: 'login_challenge',
+      });
 
       await expect(interactionType.handleDecision(parameters)).rejects.toThrow(
         new InvalidRequestException({ description: 'Invalid parameter "subject".' })
@@ -214,7 +225,11 @@ describe('Login Interaction Type', () => {
       Reflect.set(parameters, 'decision', 'accept');
       Reflect.set(parameters, 'subject', 'user_id');
 
-      sessionServiceMock.findOne.mockResolvedValueOnce(<Session>{ id: 'session_id' });
+      sessionServiceMock.findOneByLoginChallenge.mockResolvedValueOnce(<Session>{
+        id: 'session_id',
+        loginChallenge: 'login_challenge',
+      });
+
       userServiceMock.findOne.mockResolvedValueOnce(null);
 
       await expect(interactionType.handleDecision(parameters)).rejects.toThrow(
@@ -235,10 +250,10 @@ describe('Login Interaction Type', () => {
         response_mode: 'query',
       };
 
-      const session = <Session>{ id: 'session_id', parameters: sessionParameters };
+      const session = <Session>{ id: 'session_id', loginChallenge: 'login_challenge', parameters: sessionParameters };
       const user = <User>{ id: 'user_id' };
 
-      sessionServiceMock.findOne.mockResolvedValueOnce(session);
+      sessionServiceMock.findOneByLoginChallenge.mockResolvedValueOnce(session);
       userServiceMock.findOne.mockResolvedValueOnce(user);
 
       const urlParameters = new URLSearchParams(sessionParameters);
@@ -254,7 +269,10 @@ describe('Login Interaction Type', () => {
     it('should throw when the parameter "error" is not provided.', async () => {
       Reflect.set(parameters, 'decision', 'deny');
 
-      sessionServiceMock.findOne.mockResolvedValueOnce(<Session>{ id: 'session_id' });
+      sessionServiceMock.findOneByLoginChallenge.mockResolvedValueOnce(<Session>{
+        id: 'session_id',
+        loginChallenge: 'login_challenge',
+      });
 
       await expect(interactionType.handleDecision(parameters)).rejects.toThrow(
         new InvalidRequestException({ description: 'Invalid parameter "error".' })
@@ -267,7 +285,10 @@ describe('Login Interaction Type', () => {
 
       Reflect.deleteProperty(parameters, 'error_description');
 
-      sessionServiceMock.findOne.mockResolvedValueOnce(<Session>{ id: 'session_id' });
+      sessionServiceMock.findOneByLoginChallenge.mockResolvedValueOnce(<Session>{
+        id: 'session_id',
+        loginChallenge: 'login_challenge',
+      });
 
       await expect(interactionType.handleDecision(parameters)).rejects.toThrow(
         new InvalidRequestException({ description: 'Invalid parameter "error_description".' })
@@ -279,7 +300,10 @@ describe('Login Interaction Type', () => {
       Reflect.set(parameters, 'error', 'custom_error');
       Reflect.set(parameters, 'error_description', 'Custom error description.');
 
-      sessionServiceMock.findOne.mockResolvedValueOnce(<Session>{ id: 'session_id' });
+      sessionServiceMock.findOneByLoginChallenge.mockResolvedValueOnce(<Session>{
+        id: 'session_id',
+        loginChallenge: 'login_challenge',
+      });
 
       userServiceMock.findOne.mockResolvedValueOnce({ id: 'user_id' });
 

--- a/packages/oauth2-server/src/lib/interaction-types/login.interaction-type.ts
+++ b/packages/oauth2-server/src/lib/interaction-types/login.interaction-type.ts
@@ -75,7 +75,7 @@ export class LoginInteractionType implements InteractionTypeInterface {
   public async handleContext(parameters: LoginContextInteractionRequest): Promise<LoginContextInteractionResponse> {
     this.checkContextParameters(parameters);
 
-    const session = await this.getSession(parameters.login_challenge);
+    const session = await this.getSessionByLoginChallenge(parameters.login_challenge);
 
     await this.checkSession(session);
 
@@ -116,7 +116,7 @@ export class LoginInteractionType implements InteractionTypeInterface {
   public async handleDecision(parameters: LoginDecisionInteractionRequest): Promise<LoginDecisionInteractionResponse> {
     this.checkDecisionParameters(parameters);
 
-    const session = await this.getSession(parameters.login_challenge);
+    const session = await this.getSessionByLoginChallenge(parameters.login_challenge);
 
     await this.checkSession(session);
 
@@ -235,14 +235,14 @@ export class LoginInteractionType implements InteractionTypeInterface {
   /**
    * Fetches the requested Session from the application's storage.
    *
-   * @param id Identifier provided by the Client.
-   * @returns Session based on the provided Identifier.
+   * @param loginChallenge Login Challenge provided by the Client.
+   * @returns Session based on the provided Login Challenge.
    */
-  private async getSession(id: string): Promise<Session> {
-    const session = await this.sessionService.findOne(id);
+  private async getSessionByLoginChallenge(loginChallenge: string): Promise<Session> {
+    const session = await this.sessionService.findOneByLoginChallenge(loginChallenge);
 
     if (session === null) {
-      throw new AccessDeniedException({ description: 'Invalid Session.' });
+      throw new AccessDeniedException({ description: 'Invalid Login Challenge.' });
     }
 
     return session;

--- a/packages/oauth2-server/src/lib/services/consent.service.interface.ts
+++ b/packages/oauth2-server/src/lib/services/consent.service.interface.ts
@@ -28,6 +28,14 @@ export interface ConsentServiceInterface {
   findOne(id: string): Promise<Consent | null>;
 
   /**
+   * Searches the application's storage for a Consent containing the provided Consent Challenge.
+   *
+   * @param consentChallenge Consent Challenge of the Consent.
+   * @returns Consent based on the provided Consent Challenge.
+   */
+  findOneByConsentChallenge(consentChallenge: string): Promise<Consent | null>;
+
+  /**
    * Persists the provided Consent into the application's storage.
    *
    * @param consent Consent to be persisted.

--- a/packages/oauth2-server/src/lib/services/default/consent.service.ts
+++ b/packages/oauth2-server/src/lib/services/default/consent.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@guarani/di';
 
-import { randomUUID } from 'crypto';
+import { randomBytes, randomUUID } from 'crypto';
 import { Client } from '../../entities/client.entity';
 
 import { Consent } from '../../entities/consent.entity';
@@ -26,6 +26,7 @@ export class ConsentService implements ConsentServiceInterface {
       id: randomUUID(),
       scopes: [],
       loginChallenge,
+      consentChallenge: randomBytes(16).toString('hex'),
       parameters,
       createdAt: new Date(),
       client,
@@ -39,6 +40,10 @@ export class ConsentService implements ConsentServiceInterface {
 
   public async findOne(id: string): Promise<Consent | null> {
     return this.consents.find((consent) => consent.id === id) ?? null;
+  }
+
+  public async findOneByConsentChallenge(consentChallenge: string): Promise<Consent | null> {
+    return this.consents.find((consent) => consent.consentChallenge === consentChallenge) ?? null;
   }
 
   public async save(consent: Consent): Promise<void> {

--- a/packages/oauth2-server/src/lib/services/default/session.service.ts
+++ b/packages/oauth2-server/src/lib/services/default/session.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@guarani/di';
 
-import { randomUUID } from 'crypto';
+import { randomBytes, randomUUID } from 'crypto';
 
 import { Client } from '../../entities/client.entity';
 import { Session } from '../../entities/session.entity';
@@ -18,6 +18,7 @@ export class SessionService implements SessionServiceInterface {
   public async create(parameters: AuthorizationRequest, client: Client): Promise<Session> {
     const session: Session = {
       id: randomUUID(),
+      loginChallenge: randomBytes(16).toString('hex'),
       parameters,
       createdAt: new Date(),
       client,
@@ -31,6 +32,10 @@ export class SessionService implements SessionServiceInterface {
 
   public async findOne(id: string): Promise<Session | null> {
     return this.sessions.find((session) => session.id === id) ?? null;
+  }
+
+  public async findOneByLoginChallenge(loginChallenge: string): Promise<Session | null> {
+    return this.sessions.find((session) => session.loginChallenge === loginChallenge) ?? null;
   }
 
   public async save(session: Session): Promise<void> {

--- a/packages/oauth2-server/src/lib/services/session.service.interface.ts
+++ b/packages/oauth2-server/src/lib/services/session.service.interface.ts
@@ -25,6 +25,14 @@ export interface SessionServiceInterface {
   findOne(id: string): Promise<Session | null>;
 
   /**
+   * Searches the application's storage for a Session containing the provided Login Challenge.
+   *
+   * @param loginChallenge Login Challenge of the Session.
+   * @returns Session based on the provided Login Challenge.
+   */
+  findOneByLoginChallenge(loginChallenge: string): Promise<Session | null>;
+
+  /**
    * Persists the provided Session into the application's storage.
    *
    * @param session Session to be persisted.

--- a/packages/oauth2-server/tests/authorization-code-flow.spec.ts
+++ b/packages/oauth2-server/tests/authorization-code-flow.spec.ts
@@ -63,7 +63,7 @@ describe('Authorization Code Flow', () => {
     const loginChallenge = loginUrl.searchParams.get('login_challenge')!;
 
     expect(loginAuthorizationResponse.status).toBe(303);
-    expect(agent.jar.getCookie('guarani:session', CookieAccessInfo.All)?.value).toBe(loginChallenge);
+    expect(agent.jar.getCookie('guarani:session', CookieAccessInfo.All)?.value).toEqual(expect.any(String));
     // #endregion
 
     // #region Create the Session within the Authorization Server.
@@ -108,7 +108,7 @@ describe('Authorization Code Flow', () => {
     const consentChallenge = consentUrl.searchParams.get('consent_challenge')!;
 
     expect(consentAuthorizationResponse.status).toBe(303);
-    expect(agent.jar.getCookie('guarani:consent', CookieAccessInfo.All)?.value).toBe(consentChallenge);
+    expect(agent.jar.getCookie('guarani:consent', CookieAccessInfo.All)?.value).toEqual(expect.any(String));
     // #endregion
 
     // # Create the Consent within the Authorization Server.


### PR DESCRIPTION
Interactions now use login and consent challenges instead of session and consent identifiers.